### PR TITLE
Allow passing a custom compare function for dataframe uploads to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Clean data in Pandas dataframe
 - Convert dataframe to .csv
 - Store .csv in S3 bucket as text file
-- Deploy scraper to AWS lambda and run it there every 3 minutes
+- Deploy scraper to AWS lambda and run it there every 15 minutes
 
 ## Creating a new scraper
 - Create a copy of the `scraper_template.py` file or one of the existing scrapers
@@ -25,4 +25,4 @@
 ## Error reporting
 - Any errors in a scraper are reported to Sentry
 - Use asserts to confirm the data is valid
-- If non-critical but interesting changes to the data are noticed, report them to Slack via webhook
+- If non-critical but interesting changes to the data are noticed, report them to Slack via Sentry message

--- a/get_data_mags_nrw.py
+++ b/get_data_mags_nrw.py
@@ -214,7 +214,7 @@ def write_data_nrw():
     df = df[df['Landkreis/ kreisfreie Stadt'] != 'Gesamt']
 
     upload_dataframe(
-        df, filename, change_notifcation=f'Mags-Daten aktualisiert')
+        df, filename, change_notification=f'Mags-Daten aktualisiert')
 
     for studio, areas in studios.items():
         df_studio = df[df['Landkreis/ kreisfreie Stadt'].isin(areas)]

--- a/get_data_rki_ndr_districts.py
+++ b/get_data_rki_ndr_districts.py
@@ -1,10 +1,12 @@
 from functools import lru_cache
 from io import BytesIO
+from datetime import datetime
 
 import requests
 import pandas as pd
+from pytz import timezone
 
-from utils.storage import upload_dataframe
+from utils.storage import upload_dataframe, make_df_compare_fn
 
 url = 'https://ndrdata-corona-datastore.storage.googleapis.com/rki_api/current_cases_regions.csv'
 
@@ -69,6 +71,9 @@ def clear_data():
 
     df = df.rename(columns={"IdLandkreis": "ID"})
 
+    # Add update date
+    df['Stand'] = datetime.now(timezone('Europe/Berlin')).strftime('%d.%m.%y 0:00 Uhr')
+
     return df
 
 
@@ -76,7 +81,8 @@ def write_data_rki_ndr_districts():
     df = clear_data()
     filename = 'rki_ndr_districts.csv'
 
-    upload_dataframe(df, filename)
+    compare = make_df_compare_fn(ignore_columns=['Stand'])
+    upload_dataframe(df, filename, compare=compare)
 
 
 # If the file is executed directly, print cleaned data

--- a/get_data_rki_ndr_districts_nrw.py
+++ b/get_data_rki_ndr_districts_nrw.py
@@ -110,7 +110,7 @@ def write_data_rki_ndr_districts_nrw():
     df = df[df['Landkreis/ kreisfreie Stadt'] != 'Gesamt']
 
     upload_dataframe(
-        df, filename, change_notifcation=f'Mags-Daten aktualisiert')
+        df, filename, change_notifcation=f'RKI-Daten für NRW aktualisiert')
 
     for studio, areas in studios.items():
         df_studio = df[df['Landkreis/ kreisfreie Stadt'].isin(areas)]

--- a/get_data_rki_ndr_districts_nrw.py
+++ b/get_data_rki_ndr_districts_nrw.py
@@ -115,7 +115,7 @@ def write_data_rki_ndr_districts_nrw():
     df = df[df['Landkreis/ kreisfreie Stadt'] != 'Gesamt']
 
     upload_dataframe(
-        df, filename, change_notifcation=f'RKI-Daten für NRW aktualisiert', compare=compare)
+        df, filename, change_notification=f'RKI-Daten für NRW aktualisiert', compare=compare)
 
     for studio, areas in studios.items():
         df_studio = df[df['Landkreis/ kreisfreie Stadt'].isin(areas)]

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,7 @@ functions:
     events:
       - schedule:
           name: ${self:service}-${self:provider.stage}-scrape
-          rate: rate(3 minutes)
+          rate: rate(15 minutes)
           enabled: true
 
 plugins:

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -1,7 +1,9 @@
 import os
 from io import BytesIO
 from datetime import datetime
+
 import pytz
+import pandas as pd
 
 from botocore.exceptions import ClientError
 from boto3 import client

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -40,7 +40,7 @@ def download_file(filename):
     return bio
 
 
-def upload_dataframe(df, filename, *, change_notifcation=None, compare=None):
+def upload_dataframe(df, filename, *, change_notification=None, compare=None):
 
     if compare is None:
         compare = simple_compare
@@ -61,8 +61,8 @@ def upload_dataframe(df, filename, *, change_notifcation=None, compare=None):
 
     if compare_failed or not compare(bio_old.read(), write):
         # Notify
-        if change_notifcation and not compare_failed:
-            sentry_sdk.capture_message(change_notifcation)
+        if change_notification and not compare_failed:
+            sentry_sdk.capture_message(change_notification)
 
         # Create new file-like object for upload
         bio_new = BytesIO(write)


### PR DESCRIPTION
The reason we need this is because we want to add the current date to our scraped data sometimes, but without that being considered when checking if the data itself has been updated. Therefore, we now allow passing a custom compare function. I also wrote a little factory for making compare functions that parse the data into dataframes and compare those, while ignoring certain columns for the comparison.